### PR TITLE
Add apply_filters hook to prepare_query_args

### DIFF
--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -357,6 +357,8 @@ class ProductRepository implements Service {
 			$args['orderby'] = 'none';
 		}
 
+		$args = apply_filters('gla_filter_product_query_args', $args);
+		
 		return $args;
 	}
 


### PR DESCRIPTION
Provides the ability to control the product selection of synced products.

### Changes proposed in this Pull Request:

Adding an apply filters hook allows users more control over which products can be selected for syncing.

Closes #2005

### Additional details:
Tweak - Ability to filter products for syncing via `gla_filter_product_query_args` apply_filters hook.

### Changelog entry
Ability to filter products for syncing via `gla_filter_product_query_args` apply_filters hook.